### PR TITLE
feat(cli): skip license user limit

### DIFF
--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -114,7 +114,7 @@ export class AuthService {
 	issueCookie(res: Response, user: User, browserId?: string) {
 		// TODO: move this check to the login endpoint in AuthController
 		// If the instance has exceeded its user quota, prevent non-owners from logging in
-		const isWithinUsersLimit = this.license.isWithinUsersLimit();
+		const isWithinUsersLimit = this.license.isWithinUsersLimitOrSkip();
 		if (
 			config.getEnv('userManagement.isInstanceOwnerSetUp') &&
 			!user.isOwner &&

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -130,7 +130,7 @@ export class AuthController {
 		@Query payload: ResolveSignupTokenQueryDto,
 	) {
 		const { inviterId, inviteeId } = payload;
-		const isWithinUsersLimit = this.license.isWithinUsersLimit();
+		const isWithinUsersLimit = this.license.isWithinUsersLimitOrSkip();
 
 		if (!isWithinUsersLimit) {
 			this.logger.debug('Request to resolve signup token failed because of users quota reached', {

--- a/packages/cli/src/controllers/password-reset.controller.ts
+++ b/packages/cli/src/controllers/password-reset.controller.ts
@@ -63,7 +63,7 @@ export class PasswordResetController {
 		// User should just be able to reset password if one is already present
 		const user = await this.userRepository.findNonShellUser(email);
 
-		if (!user?.isOwner && !this.license.isWithinUsersLimit()) {
+		if (!user?.isOwner && !this.license.isWithinUsersLimitOrSkip()) {
 			this.logger.debug(
 				'Request to send password reset email failed because the user limit was reached',
 			);
@@ -140,7 +140,7 @@ export class PasswordResetController {
 		const user = await this.authService.resolvePasswordResetToken(token);
 		if (!user) throw new NotFoundError('');
 
-		if (!user?.isOwner && !this.license.isWithinUsersLimit()) {
+		if (!user?.isOwner && !this.license.isWithinUsersLimitOrSkip()) {
 			this.logger.debug(
 				'Request to resolve password token failed because the user limit was reached',
 				{ userId: user.id },

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -409,6 +409,10 @@ export class License {
 		return this.getUsersLimit() === UNLIMITED_LICENSE_QUOTA;
 	}
 
+	isWithinUsersLimitOrSkip() {
+		return process.env.N8N_SKIP_LICENSE_CHECK === 'true' || this.isWithinUsersLimit();
+	}
+
 	/**
 	 * Ensures that the instance is licensed for multi-main setup if multi-main mode is enabled
 	 */


### PR DESCRIPTION
## Summary
- add `isWithinUsersLimitOrSkip` helper to bypass user limit when N8N_SKIP_LICENSE_CHECK is true
- refactor auth and password reset flows to rely on new helper

## Testing
- `pnpm --filter cli test` *(no projects matched)*
- `pnpm --filter n8n test` *(fails: Cannot find module '@n8n/config')*
