### PR TITLE
log license bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este projeto aplica customizações ao n8n Community para desbloquear recursos E
 
 ## 🚀 Recursos Habilitados
 
-- **Pular checagem de licença** (`N8N_SKIP_LICENSE_CHECK=true`)
+- **Pular checagem de licença** (`N8N_SKIP_LICENSE_CHECK=true`) com log informativo quando o bypass está ativo
 - **Suporte a múltiplos usuários** (convite por e-mail, roles)
 - **Recursos Enterprise** (admin, compartilhamento, etc.)
 - **Base para isolação por tenantId** (futura implementação)
@@ -30,10 +30,13 @@ Este projeto aplica customizações ao n8n Community para desbloquear recursos E
    - Bypass do limite de usuários: permite convidar além da cota se `N8N_SKIP_LICENSE_CHECK=true`.
    - Lógica de convite por e-mail com checagem de permissão de admin.
 
-4. **`packages/frontend/editor-ui/src/stores/settings.store.ts`**
+4. **`packages/cli/src/license.ts`**
+   - Registro em log quando o limite de usuários é ignorado (`N8N_SKIP_LICENSE_CHECK=true`).
+
+5. **`packages/frontend/editor-ui/src/stores/settings.store.ts`**
    - Exposição de flags de licença (enterprise) ao frontend.
 
-5. **`packages/frontend/editor-ui/src/stores/settings.store.ts`** *(nova modificação)*
+6. **`packages/frontend/editor-ui/src/stores/settings.store.ts`** *(nova modificação)*
    - **HACK**: remove o banner “não-produção” configurando
      ```ts
      if (settings.value.enterprise) {

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -114,7 +114,7 @@ export class AuthService {
 	issueCookie(res: Response, user: User, browserId?: string) {
 		// TODO: move this check to the login endpoint in AuthController
 		// If the instance has exceeded its user quota, prevent non-owners from logging in
-		const isWithinUsersLimit = this.license.isWithinUsersLimitOrSkip();
+		const isWithinUsersLimit = this.license.isWithinUsersLimitOrSkip(this.logger);
 		if (
 			config.getEnv('userManagement.isInstanceOwnerSetUp') &&
 			!user.isOwner &&

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -130,7 +130,7 @@ export class AuthController {
 		@Query payload: ResolveSignupTokenQueryDto,
 	) {
 		const { inviterId, inviteeId } = payload;
-		const isWithinUsersLimit = this.license.isWithinUsersLimitOrSkip();
+		const isWithinUsersLimit = this.license.isWithinUsersLimitOrSkip(this.logger);
 
 		if (!isWithinUsersLimit) {
 			this.logger.debug('Request to resolve signup token failed because of users quota reached', {

--- a/packages/cli/src/controllers/password-reset.controller.ts
+++ b/packages/cli/src/controllers/password-reset.controller.ts
@@ -63,7 +63,7 @@ export class PasswordResetController {
 		// User should just be able to reset password if one is already present
 		const user = await this.userRepository.findNonShellUser(email);
 
-		if (!user?.isOwner && !this.license.isWithinUsersLimitOrSkip()) {
+		if (!user?.isOwner && !this.license.isWithinUsersLimitOrSkip(this.logger)) {
 			this.logger.debug(
 				'Request to send password reset email failed because the user limit was reached',
 			);
@@ -140,7 +140,7 @@ export class PasswordResetController {
 		const user = await this.authService.resolvePasswordResetToken(token);
 		if (!user) throw new NotFoundError('');
 
-		if (!user?.isOwner && !this.license.isWithinUsersLimitOrSkip()) {
+		if (!user?.isOwner && !this.license.isWithinUsersLimitOrSkip(this.logger)) {
 			this.logger.debug(
 				'Request to resolve password token failed because the user limit was reached',
 				{ userId: user.id },

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -409,8 +409,14 @@ export class License {
 		return this.getUsersLimit() === UNLIMITED_LICENSE_QUOTA;
 	}
 
-	isWithinUsersLimitOrSkip() {
-		return process.env.N8N_SKIP_LICENSE_CHECK === 'true' || this.isWithinUsersLimit();
+	isWithinUsersLimitOrSkip(logger?: Logger) {
+		const bypass = process.env.N8N_SKIP_LICENSE_CHECK === 'true';
+		if (bypass) {
+			(logger ?? this.logger).debug(
+				'Bypassing users limit check because N8N_SKIP_LICENSE_CHECK=true',
+			);
+		}
+		return bypass || this.isWithinUsersLimit();
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- log when user-limit check is bypassed
- inject loggers for user-limit bypass in auth and password reset flows
- document logging behavior for license bypass

## Testing
- `pnpm exec biome check packages/cli/src/license.ts packages/cli/src/controllers/auth.controller.ts packages/cli/src/auth/auth.service.ts packages/cli/src/controllers/password-reset.controller.ts README.md`
- `pnpm test --filter n8n` *(fails: Cannot find module '@n8n/config/dist/index.js')*
